### PR TITLE
measure time in the tests

### DIFF
--- a/bitalg/tests/test1.py
+++ b/bitalg/tests/test1.py
@@ -1,4 +1,3 @@
-import timeit
 from .test_core import TestCore
 from numpy import linalg, array
 from random import uniform
@@ -6,15 +5,15 @@ from random import uniform
 class Test(TestCore):
     def runtest(self, task_no, *func):
         """
-            Checks the correctness of the function and measures its execution time
+            Checks the correctness of the function
             :param task_no: number of task
             :param func: name of functions to test
             :return:
         """
         if task_no == 1:
-            print("Time: {}s\n".format(round(timeit.timeit(lambda: TestCore.test(self, 1, 1, self.task1_func, *func), number=1), 3)))
+            TestCore.test(self, 1, 1, self.task1_func, *func)
         else:
-            print("Time: {}ms\n".format(round(1000*timeit.timeit(lambda: TestCore.test(self, 1, 2, self.task2_func, *func), number=1), 3)))
+            TestCore.test(self, 1, 2, self.task2_func, *func)
 
     # 10**5 numbers from interval [-1000, 1000]
     # 10**5 numbers from interval [-10**14, 10**14]

--- a/bitalg/tests/test3.py
+++ b/bitalg/tests/test3.py
@@ -1,20 +1,19 @@
-import timeit
 from .test_core import TestCore, get_test_path
 
 class Test(TestCore):
     def runtest(self, task_no, func):
         """
-        Checks the correctness of the function and measures its execution time
+        Checks the correctness of the function
         :param task_no: number of task
         :param func: name of function to test
         :return:
         """
         if task_no == 1:
-            print("Time: {}ms\n".format(round(1000*timeit.timeit(lambda: TestCore.test(self, 3, 1, self.task1_func, func), number=1), 3)))
+            TestCore.test(self, 3, 1, self.task1_func, func)
         elif task_no == 2:
-            print("Time: {}ms\n".format(round(1000*timeit.timeit(lambda: TestCore.test(self, 3, 2, self.task2_func, func), number=1), 3)))
+            TestCore.test(self, 3, 2, self.task2_func, func)
         else:
-            print("Time: {}ms\n".format(round(1000*timeit.timeit(lambda: TestCore.test(self, 3, 3, self.task3_func, func), number=1), 3)))
+            TestCore.test(self, 3, 3, self.task3_func, func)
 
     @staticmethod
     def read_data(task_no, test_no):

--- a/bitalg/tests/test_core.py
+++ b/bitalg/tests/test_core.py
@@ -1,4 +1,5 @@
 from os import path, listdir
+from time import process_time
 from bitalg import __path__ as pkg_path
 
 
@@ -7,11 +8,14 @@ def get_test_path(lab_no, task_no, test_no):
 
 
 class TestCore:
+    sum_time = 0
     def __init__(self):
         self.tests_in = [[4, 2],  # number of tests in [lab-1 = row][task-1 = column]
                          [11, 11],  # lab 2
                          [10, 10, 10],  # lab 3
                          [3, 3, 3]]  # lab 4
+    def __del__(self):
+        print(f"Time: {self.sum_time:.3f}s")
 
     def test(self, lab_no, task_no, test_func, func, *args):
         print("Lab {}, task {}:".format(lab_no, task_no))
@@ -25,7 +29,10 @@ class TestCore:
         for test_no in range(1, limit):
             print(f"\tTest {test_no}:", end=" ")
 
+            timer_start = process_time()
             result, *output_expected = test_func(test_no, func, *args)
+            timer_stop = process_time()
+            self.sum_time += timer_stop - timer_start
 
             if result == 1:
                 print("Passed")


### PR DESCRIPTION
Measuring time from two test files where this was already implemented has been removed. Instead, measuring time in `test_core` using the destructor of the `Test` object has been implemented.