### PR TITLE
Fix rounding error

### DIFF
--- a/bitalg/tests/test4.py
+++ b/bitalg/tests/test4.py
@@ -145,7 +145,8 @@ class Test(TestCore):
             else:
                 point, id1, id2 = intersection[0], intersection[1], intersection[2]
                 point = Point(point[0], point[1], eps)
-            output_dict[point] = (min(id1, id2), max(id1, id2))
+            key = (min(id1, id2), max(id1, id2))
+            output_dict[key] = point
         return output_dict
 
     def task3_fun(self, test_no, func, eps):


### PR DESCRIPTION
Występował u mnie błąd polegający na tym, że prawie wszystkie testy w lab4.task3 nie przechodziły. Był to błąd związany z porównywaniem dictów. W przykładzie poniżej dane mieszczą się w błędzie, jednak porównanie dictów zwraca `False`, mimo że porównanie kluczy daje `True`.

```python3
from bitalg.tests.test4 import Test, Point

eps = 0.1
Point(1, 2, eps=0.1) == Point(1.00001, 2, eps) # True
a = Test.list_to_dictionary([((1, 2), 1, 2)], eps)
b = Test.list_to_dictionary([((1.00001, 2), 1, 2)], eps)
a == b # False
list(a.keys()) == list(b.keys()) # True
```

CPython porównuje dicty używając hasha kluczy zamiast ich eq. Żeby nie być gołosłownym [funkcja porównująca 2 dicty w cpythonie](https://github.com/python/cpython/blob/45650d1c479a8b0370f126d821718dd3c502f333/Objects/dictobject.c#L3250-L3307) - ogarnia ona hashe kluczy jednego dicta i robi lookup po tych hashach w drugim dictcie.

Poprzednia implementacja nie uwzględniała epsilona przy metodzie `Point.__hash__`, przez co porównywanie dwóch słowników w funkcji [`task3_fun`](https://github.com/aghbit/Algorytmy-Geometryczne/blob/c63138fc5d8ac20590b08e6250beba6e6196dc9b/bitalg/tests/test4.py#L151-L172C33) o kluczach będących punktami nie działało, gdy współrzędne x-owe dwóch puktów były chociażby minimalnie różne, nawet jeśli mieściło się to w błędzie zadanym przez epsilona.

Teraz przed hashem współrzędna x-owa jest zaokrąglana funkcją `round` do tylu miejsc po przecinku ile miejsc po przecinku ma liczba `eps` (w przybliżeniu). Po zmianach poniższy snippet daje `True` w odpowiednich momentach
```python3
from bitalg.tests.test4 import Test, Point

eps = 0.1
Point(1, 2, eps=0.1) == Point(1.00001, 2, eps) # True
a = Test.list_to_dictionary([((1, 2), 1, 2)], eps)
b = Test.list_to_dictionary([((1.00001, 2), 1, 2)], eps)
a == b # True
list(a.keys()) == list(b.keys()) # True

a = Test.list_to_dictionary([((1, 2), 1, 2)], eps)
b = Test.list_to_dictionary([((1.1, 2), 1, 2)], eps)
a == b # False
list(a.keys()) == list(b.keys()) # False
```

U mnie działa

Ewentualnie można zmienić dicty jakoś na listy i posortować i też powinno być ok